### PR TITLE
hotfix for :ns-tracker/resource-deps

### DIFF
--- a/src/repl_reload/core.clj
+++ b/src/repl_reload/core.clj
@@ -1,5 +1,8 @@
 (ns repl-reload.core
   (:require [clojure.tools.namespace.repl :as repl]
+            [clojure.tools.namespace.dir :as dir]
+            [clojure.tools.namespace.find :as find]
+            [clojure.tools.namespace.file :as file]
             [clojure.java.classpath :as classpath]
             [ns-tracker.core :as tracker]))
 
@@ -11,6 +14,35 @@
           target (second aliased)]
       (ns-unalias *ns* sym)
       (alias sym (symbol (.toString target))))))
+
+(defn- get-files-of-ns [tracker target-ns-list]
+  (let [target? (set target-ns-list)]
+    (reduce-kv (fn [aux file ns]
+                 (if (target? ns)
+                   (conj aux
+                         file)
+                   aux))
+               []
+               (::file/filemap tracker))))
+
+(defn- touch-files-of-ns-aux [tracker changed-ns-list]
+  (let [files (get-files-of-ns tracker
+                               changed-ns-list)]
+    (if (seq files)
+      (dir/scan-files tracker
+                      files
+                      {:platform find/clj
+                       :add-all? true})
+      tracker)))
+
+(defn- touch-files-of-ns
+  "Forcibly reload files corresponding `changed-ns`.
+  It makes :ns-tracker/resource-deps work again.
+  See https://github.com/weavejester/ns-tracker#declaring-dependencies-to-static-resources"
+  [changed-ns-list]
+  (alter-var-root #'repl/refresh-tracker
+                  touch-files-of-ns-aux
+                  changed-ns-list))
 
 (defn reload []
   (try
@@ -35,7 +67,9 @@
       #(while true (binding [*ns* my-ns
                              *out* my-out]
                      (Thread/sleep 500)
-                     (when (pos? (count (track)))
-                       (reload)))))
+                     (let [changed-ns (track)]
+                       (when (seq changed-ns)
+                         (touch-files-of-ns changed-ns)
+                         (reload))))))
       (.setDaemon true)
       (.start))))

--- a/src/repl_reload/core.clj
+++ b/src/repl_reload/core.clj
@@ -1,5 +1,6 @@
 (ns repl-reload.core
   (:require [clojure.tools.namespace.repl :as repl]
+            [clojure.java.classpath :as classpath]
             [ns-tracker.core :as tracker]))
 
 (defonce my-aliases (atom nil))
@@ -26,7 +27,7 @@
 
 (defn auto-reload []
   (let [track (tracker/ns-tracker
-               (mapv str (clojure.java.classpath/classpath-directories)))
+               (mapv str (classpath/classpath-directories)))
         my-ns *ns*
         my-out *out*]
     (doto


### PR DESCRIPTION
`ns-tracker` supports declaring dependencies to static resources.
(See https://github.com/weavejester/ns-tracker#declaring-dependencies-to-static-resources)
However, `clojure.tools.namespace` does not have any machanism for it.

This patch lets `ns-tracker` to calculate namespaces to reload
and makes sure that `clojure.tools` actually reloads them even when
the corresponding files have not changed.